### PR TITLE
feat: make build.py cross-compatible

### DIFF
--- a/build.py
+++ b/build.py
@@ -4,22 +4,25 @@ import shutil
 
 def build_exe():
     print("Building XNull Music Bot executable...")
-    
+
     # Clean previous builds
     if os.path.exists('build'):
         shutil.rmtree('build')
     if os.path.exists('dist'):
         shutil.rmtree('dist')
-    
+
+    # Use os.pathsep to set the proper separator based on the operating system
+    data_sep = os.pathsep
+
     # PyInstaller options
     PyInstaller.__main__.run([
-        'main.py',                        # Your main script
-        '--name=XNull Music Bot',         # Name of the executable
-        '--onefile',                      # Create a single executable
-        '--add-data=cogs;cogs',           # Include cogs directory
-        '--add-data=utils;utils',         # Include utils directory
-        '--icon=logo.ico',                # Add icon if you have one
-        '--clean',                        # Clean cache
+        'main.py',                          # Your main script
+        '--name=XNull Music Bot',           # Name of the executable
+        '--onefile',                        # Create a single executable
+        f'--add-data=cogs{data_sep}cogs',   # Include cogs directory
+        f'--add-data=utils{data_sep}utils', # Include utils directory
+        '--icon=logo.ico',                  # Add icon if you have one
+        '--clean',                          # Clean cache
         # Discord.py related imports
         '--hidden-import=discord',
         '--hidden-import=discord.ui',
@@ -42,7 +45,7 @@ def build_exe():
         '--hidden-import=requests',
         '--hidden-import=bs4',
         '--hidden-import=beautifulsoup4',
-        '--hidden-import=soupsieve',  # Required by beautifulsoup4
+        '--hidden-import=soupsieve',        # Required by beautifulsoup4
         # Collect all packages
         '--collect-all=yt_dlp',
         '--collect-all=discord',
@@ -50,9 +53,9 @@ def build_exe():
         '--collect-all=bs4',
         '--collect-all=requests',
     ])
-    
+
     print("\nBuild complete! Check the 'dist' folder for your executable.")
     print("\nVisit https://www.xnull.eu for more projects and tools!")
 
 if __name__ == "__main__":
-    build_exe() 
+    build_exe()


### PR DESCRIPTION
I tried building the bot on Linux and noticed this error:

```
❯ python build.py
Building XNull Music Bot executable...
usage: pyinstaller [-h] [-v] [-D] [-F] [--specpath DIR] [-n NAME] [--contents-directory CONTENTS_DIRECTORY] [--add-data SOURCE:DEST]
                   [--add-binary SOURCE:DEST] [-p DIR] [--hidden-import MODULENAME] [--collect-submodules MODULENAME] [--collect-data MODULENAME]
                   [--collect-binaries MODULENAME] [--collect-all MODULENAME] [--copy-metadata PACKAGENAME] [--recursive-copy-metadata PACKAGENAME]
                   [--additional-hooks-dir HOOKSPATH] [--runtime-hook RUNTIME_HOOKS] [--exclude-module EXCLUDES] [--splash IMAGE_FILE]
                   [-d {all,imports,bootloader,noarchive}] [--optimize LEVEL] [--python-option PYTHON_OPTION] [-s] [--noupx] [--upx-exclude FILE]
                   [-c] [-w] [--hide-console {minimize-late,hide-early,minimize-early,hide-late}]
                   [-i <FILE.ico or FILE.exe,ID or FILE.icns or Image or "NONE">] [--disable-windowed-traceback] [--version-file FILE]
                   [--manifest <FILE or XML>] [-m <FILE or XML>] [-r RESOURCE] [--uac-admin] [--uac-uiaccess] [--argv-emulation]
                   [--osx-bundle-identifier BUNDLE_IDENTIFIER] [--target-architecture ARCH] [--codesign-identity IDENTITY]
                   [--osx-entitlements-file FILENAME] [--runtime-tmpdir PATH] [--bootloader-ignore-signals] [--distpath DIR] [--workpath WORKPATH]
                   [-y] [--upx-dir UPX_DIR] [--clean] [--log-level LEVEL]
                   scriptname [scriptname ...]
pyinstaller: error: argument --add-data: Wrong syntax, should be --add-data=SOURCE:DEST

```

So I introduced the use of "os.pathsep" to make it cross-compatible with Linux and MacOS as-well.